### PR TITLE
fix: update CSS selector for stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "packageManager": "pnpm@10.9.0",
   "devDependencies": {
     "@playwright/test": "^1.52.0",
-    "@types/node": "^22.15.21"
+    "@types/node": "^22.15.21",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "fastify": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^22.15.21
         version: 22.15.21
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -209,6 +212,11 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -405,5 +413,7 @@ snapshots:
       real-require: 0.2.0
 
   toad-cache@3.7.0: {}
+
+  typescript@5.9.3: {}
 
   undici-types@6.21.0: {}

--- a/src/routes/art/view/[artist]/[post]/index.ts
+++ b/src/routes/art/view/[artist]/[post]/index.ts
@@ -41,7 +41,7 @@ export default async (fastify: FastifyInstance, options: Object) => {
 			const image = await page.locator(".pod-body").first().locator("a").first().getAttribute("href");
 			console.log("Image source:", image);
 			console.log("Getting score...");
-			const stats = await page.locator("dd").all();
+			const stats = await page.locator("#sidestats > .sidestats > dd").all();
 			const views = "👀 " + await stats[0].textContent({ timeout: 500 });
 			const faves = "🌟 " + await stats[1].locator("#faves_load").textContent({ timeout: 500 });
 			const votes = "🖐️ " + await stats[2].textContent({ timeout: 500 });


### PR DESCRIPTION
This PR prevents the `stats` variable of containing other information and raising an error if the post's description contains an embed that contains one or more `dd` elements (like the embed of another newgrounds upload). This PR also includes a commit that adds `typescript` as a dev dependency, because it is needed for the project to run.

## Problem

Here's an exemple post to better understand this: https://www.newgrounds.com/art/view/gragax/leenar-with-the-gun
<img width="1505" height="166" alt="image" src="https://github.com/user-attachments/assets/f893c88f-a64a-4305-803b-b41ae4c7b1bc" />
As you can see, there's some `dd` elements in this post's description, which appears to be *before* the section "Credits & Info" of the page.
As a result, an error is raised and the post isn't embbeding at all:
```
Getting score...
Error occurred: locator.textContent: Timeout 500ms exceeded.
Call log:
  - waiting for locator('dd').nth(3).locator('#score_number')

    at Object.<anonymous> (src\routes\art\view\[artist]\[post]\index.ts:48:66) {
  name: 'TimeoutError'
}
```
```
GET http://localhost:7854/art/view/gragax/leenar-with-the-gun

HTTP/1.1 200 OK
content-length: 0
Date: Wed, 28 Jan 2026 21:26:55 GMT
Connection: keep-alive
Keep-Alive: timeout=72

<Response body is empty>

Response code: 200 (OK); Time: 1586ms (1 s 586 ms); Content length: 0 bytes (0 B)
```

## Solution

I've just narrowed the selector for `dd` elements, by only getting the `dd` within the sidestats.

Please note that I used a full selector implementation, by using `#sidestats > .sidestats > dd`, because it is straightforward, portable and - I think? - quicker, but if consistency is prefered, `page.locator("#sidestats").first().locator("dl").first().locator("dd").all();` also works perfectly.